### PR TITLE
fix: withdrawが0のとき何もせず成功扱いにするように変更

### DIFF
--- a/src/main/java/me/Short/TheosisEconomy/Economy.java
+++ b/src/main/java/me/Short/TheosisEconomy/Economy.java
@@ -134,8 +134,14 @@ public class Economy implements net.milkbowl.vault.economy.Economy
         BigDecimal currentBalance = TheosisEconomy.getPlayerAccounts().get(uuid).getBalance();
         BigDecimal bdAmount = instance.round(BigDecimal.valueOf(amount)).stripTrailingZeros();
         double bdAmountDoubleValue = bdAmount.doubleValue();
+        int compareBalance = bdAmount.compareTo(BigDecimal.ZERO);
 
-        if (bdAmount.compareTo(BigDecimal.ZERO) > 0) // If the amount is greater than 0...
+        if (compareBalance == 0) // If the amount is 0, do nothing.
+        {
+            return new EconomyResponse(bdAmountDoubleValue, currentBalance.doubleValue(), ResponseType.SUCCESS, null);
+        }
+
+        if (compareBalance > 0) // If the amount is greater than 0...
         {
             if (bdAmount.scale() <= fractionalDigits()) // If the amount is within the decimal place scale of the configured amount...
             {


### PR DESCRIPTION
実際には何も引かれないため、何もしない
通常だとElseでErrorが返却されるが、Vaultでエラー返却されるとJobsのポイント換算処理が永遠にキャンセルと再試行を試すことにより、ポイントが増え続けるバグがあった。